### PR TITLE
Chaib sendinblue signup abandon automation

### DIFF
--- a/back/app/Http/Controllers/Api/SendInBlueController.php
+++ b/back/app/Http/Controllers/Api/SendInBlueController.php
@@ -17,7 +17,8 @@ class SendInBlueController extends Controller
         );
         $createContact = new \SendinBlue\Client\Model\CreateContact([
             'email' => request('email'),
-            'listIds' => [233]
+            'listIds' => [request('id_liste')?request('id_liste'):233],
+            'attributes' => request('url_mission')?array('URL_MISSION_SIGNUP' => request('url_mission')):array('URL_MISSION_SIGNUP'=>'')
         ]);
 
         try {

--- a/front/components/soft-gate/Email.vue
+++ b/front/components/soft-gate/Email.vue
@@ -15,7 +15,15 @@
     </div> -->
     <div class="text-center mb-6">
       <div
-        class="text-gray-900 font-extrabold text-2xl lg:text-3xl leading-8 mb-2 lg:mb-3"
+        class="
+          text-gray-900
+          font-extrabold
+          text-2xl
+          lg:text-3xl
+          leading-8
+          mb-2
+          lg:mb-3
+        "
       >
         Avant toute chose
       </div>
@@ -35,7 +43,19 @@
           <input
             v-model.trim="form.email"
             :autofocus="true"
-            class="input-shadow text-center bg-white px-5 py-1 w-full rounded-full text-gray-900 placeholder-gray-400 focus:outline-none focus:shadow-outline"
+            class="
+              input-shadow
+              text-center
+              bg-white
+              px-5
+              py-1
+              w-full
+              rounded-full
+              text-gray-900
+              placeholder-gray-400
+              focus:outline-none
+              focus:shadow-outline
+            "
             placeholder="Votre e-mail"
             @keyup.enter.prevent="onSubmit"
           />
@@ -43,7 +63,29 @@
 
         <el-button
           :loading="loading"
-          class="font-bold max-w-sm mx-auto w-full flex items-center justify-center px-5 py-3 border border-transparent text-xl leading-6 rounded-full text-white bg-green-400 hover:bg-green-500 focus:outline-none focus:shadow-outline transition duration-150 ease-in-out"
+          class="
+            font-bold
+            max-w-sm
+            mx-auto
+            w-full
+            flex
+            items-center
+            justify-center
+            px-5
+            py-3
+            border border-transparent
+            text-xl
+            leading-6
+            rounded-full
+            text-white
+            bg-green-400
+            hover:bg-green-500
+            focus:outline-none
+            focus:shadow-outline
+            transition
+            duration-150
+            ease-in-out
+          "
           @click.prevent="onSubmit"
         >
           Continuer

--- a/front/components/soft-gate/Email.vue
+++ b/front/components/soft-gate/Email.vue
@@ -133,6 +133,11 @@ export default {
             .then((res) => {
               this.loading = false
               if (!res.data) {
+                this.$axios.post('/sendinblue/contact', {
+                  email: this.form.email,
+                  id_liste: 383,
+                  url_mission: window.location.href,
+                })
                 this.$emit('register', { email: this.form.email })
               } else {
                 this.$emit('login', res.data)


### PR DESCRIPTION
Permet de proposer aux bénévoles de terminer leurs inscriptions à leurs 1res missions sur JVA si celle-ci est commencée  mais non terminée. 

Pour l'instant, ca n'essai de "rattraper" que ceux qui on saisie leur email, mais  n'ont pas saisie leur info de base (nom, prénom, date de naissance, etc). Ca ne rattrape pas ceux qui n'ont pas envoyé le message pour participer à la mission.  